### PR TITLE
adding timeout to hanging dispose method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,4 @@ test-output/
 bin/
 catalog-v001.xml
 .cache-tests
-lib/JRDFox.jar
-lib/libCppRDFox-logAPI.dylib
-lib/libCppRDFox.dylib
-lib/libCppRDFox-logAPI.so
-lib/libCppRDFox.so
+lib/*


### PR DESCRIPTION
This puts the dataStore.dispose() call into a thread, returning a future. Then we call get() with a timeout and we can move on with our life once the timeout is reached. I set 10 minutes default (600 seconds). We just exit if we find a  timeout. Not sure what the coolest thing is here, but it doesn't hang, and in the makefile it moves on to loading BG with inferred (rdfox.ttl) and explicit ontologies. 