### PR TITLE
filtering out non ttl files when loading data files from a directory

### DIFF
--- a/src/main/scala/org/rti/bioinformatics/rdfox/Main.scala
+++ b/src/main/scala/org/rti/bioinformatics/rdfox/Main.scala
@@ -77,6 +77,7 @@ object Main extends CliMain[Unit](
       val datafiles = FileUtils.listFiles(dataFolder, null, true).asScala
         .filterNot(_.getName == "catalog-v001.xml")
         .filterNot(_.isHidden())
+        .filter(_.getName.endsWith(".ttl"))
         .filter(_.isFile).toArray
       time("Imported data files") {
         dataStore.importFiles(datafiles)


### PR DESCRIPTION
Right now this opens all the files in  the stated directory but assumes they're all ontology files. So I filtered them on *.ttl essentially, so that everything being brought in from some folder is a ttl file. In this way we don't have to necessarily have all ttl in one dir and still have this work. Feel free though to change the strategy here. Mostly I just don't want to have to move my ttl files out from my non ttl files.